### PR TITLE
Add support for Windows using rwinlib builds.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ cov
 config.log
 TODO
 README.md
+^windows

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,14 +1,26 @@
-GEOS_INC_DIR=${GEOS_HOME}/include
-GEOS_LIB_DIR=${GEOS_HOME}/lib
+COMPILED_BY ?= gcc-4.6.3
+RWINLIB = lib${subst gcc,,${COMPILED_BY}}${R_ARCH}
 
-GDAL_INC_DIR=$(GDAL_HOME)/include
-GDAL_LIB_DIR=$(GDAL_HOME)/lib
+PKG_CPPFLAGS =\
+	-I../windows/gdal2-2.1.1/include/gdal \
+	-I../windows/gdal2-2.1.1/include/geos
 
-PKG_CPPFLAGS=-I${GEOS_INC_DIR} -I$(GDAL_INC_DIR)
-ifeq "$(WIN)" "64"
-PKG_LIBS=-L${GEOS_LIB_DIR}/x64 -lgeos -L$(GDAL_LIB_DIR)/x64 -lgdal -lproj -lexpat -lsqlite3 -lodbc32 -lodbccp32 -liconv -lws2_32
-else
-PKG_LIBS=-L${GEOS_LIB_DIR}/i386 -lgeos -L$(GDAL_LIB_DIR)/i386 -lgdal -lproj -lexpat -lsqlite3 -lodbc32 -lodbccp32 -liconv -lws2_32
-endif
+PKG_LIBS = \
+	-L../windows/gdal2-2.1.1/${RWINLIB} \
+	-lgdal -lsqlite3 -lspatialite -lproj -lgeos_c -lgeos  \
+	-lhdf5 -lexpat -lfreexl -lcfitsio \
+	-lpng16 -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lszip \
+	-lodbc32 -lodbccp32 -liconv -lz -lws2_32
 
 CXX_STD=CXX11
+
+all: clean winlibs
+
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+
+clean:
+	rm -f $(OBJECTS) $(SHLIB)
+
+.PHONY: all winlibs clean
+

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,8 @@
+# Download gdal-2.0.1 from rwinlib
+if(!file.exists("../windows/gdal2-2.1.1/include/gdal/gdal.h")){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file("https://github.com/rwinlib/gdal2/archive/v2.1.1.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This turned out to be a lot of work, but I created an entirely new `gdal/geos/proj` stack with all of the good stuff for Windows.

To see what's included: https://github.com/rwinlib/gdal2

This uses the usual trick of downloading & static linking on the fly during package build on Windows.