### PR TITLE
Copy share directories into Windows binary package.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -17,7 +17,10 @@ CXX_STD=CXX11
 all: clean winlibs
 
 winlibs:
+	mkdir -p ../inst
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+	cp -r ../windows/gdal2-2.1.1/share/gdal ../inst/
+	cp -r ../windows/gdal2-2.1.1/share/proj ../inst/
 
 clean:
 	rm -f $(OBJECTS) $(SHLIB)


### PR DESCRIPTION
I think this will fix your windows build. This copies both the `./share` dirs from R winlib into the installation directory so they are bundled with the R binary package.