### PR TITLE
Cleaning up crs handling code

### DIFF
--- a/R/crs.R
+++ b/R/crs.R
@@ -104,14 +104,14 @@ crs_from_list = function(x) {
 
 	if (is.null(x$proj4string) && is.null(x$epgs)) {
 		structure(list(epsg = NA_integer_, proj4string = NA_character_), class = "crs")
-	} else if ( is.null(x$proj4string) && !is.null(x$epgs)) {
-		proj4string = trim(as.character(x$proj4string))
-		epsg = epsg_from_proj4string(proj4string)
-		structure(list(epsg = epsg, proj4string = proj4string), class = "crs")
-	} else if (!is.null(x$proj4string) &&  is.null(x$epgs)) {
-		epsg = as.integer(x$epsg)
-		proj4string = trim(CPL_proj4string_from_epsg(epsg))
-		structure(list(epsg = epsg, proj4string = proj4string), class = "crs")
+	} else if (is.null(x$proj4string) && !is.null(x$epgs)) {
+	  epsg = as.integer(x$epsg)
+	  proj4string = trim(CPL_proj4string_from_epsg(epsg))
+	  structure(list(epsg = epsg, proj4string = proj4string), class = "crs")
+	} else if (!is.null(x$proj4string) && is.null(x$epgs)) {
+	  proj4string = trim(as.character(x$proj4string))
+	  epsg = epsg_from_proj4string(proj4string)
+	  structure(list(epsg = epsg, proj4string = proj4string), class = "crs")
 	} else if (!is.null(x$proj4string) && !is.null(x$epgs)) {
 		proj4string = trim(as.character(x$proj4string))
 		epsg = as.integer(x$epsg)

--- a/R/crs.R
+++ b/R/crs.R
@@ -65,6 +65,9 @@ is.na.crs = function(x) { is.na(x$epsg) && is.na(x$proj4string) }
 	if (is.null(attr(x, "epsg")))
 		attr(x, "epsg") = NA_integer_
 
+	if (attr(x,"epsg") == 0)
+		attr(x, "epsg") = NA_integer_
+
 	attr(x, "proj4string") = trim(attr(x, "proj4string"))
 	start_crs = st_crs(x)
 	

--- a/R/read.R
+++ b/R/read.R
@@ -48,6 +48,10 @@ st_read = function(dsn, layer, ..., options = NULL, quiet = FALSE, iGeomField = 
 			NA_integer_
 		else
 			attr(geom, "proj4string")
+	
+	if (attr(geom, "epsg") == 0)
+		attr(geom, "epsg") = NA_integer_
+
 	x[[nm]] = st_sfc(geom, crs = crs)
 	st_as_sf(x, ..., stringsAsFactors = stringsAsFactors)
 }

--- a/R/read.R
+++ b/R/read.R
@@ -49,9 +49,6 @@ st_read = function(dsn, layer, ..., options = NULL, quiet = FALSE, iGeomField = 
 		else
 			attr(geom, "proj4string")
 	
-	if (attr(geom, "epsg") == 0)
-		attr(geom, "epsg") = NA_integer_
-
 	x[[nm]] = st_sfc(geom, crs = crs)
 	st_as_sf(x, ..., stringsAsFactors = stringsAsFactors)
 }

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -66,7 +66,7 @@ st_sfc = function(..., crs = NA_integer_, precision = 0.0) {
 	attr(lst, "precision") = precision
 	attr(lst, "bbox") = st_bbox(lst)
 	if (is.na(crs))
-		st_crs(lst) = attributes(lst) # they might be in there, returned from a CPL_*
+		st_crs(lst) = crs_from_list(attributes(lst)) # they might be in there, returned from a CPL_*
 	else
 		st_crs(lst) = crs
 	lst


### PR DESCRIPTION
I originally wanted to make some changed to `st_transform` but got bogged down in the crs code. I found it hard to understand all the checks and various assumptions about crs's so I've gone in and tried to revise everything to make more sense (at least to me). 

I've tried not to be too opinionated and leave the original functionality as much as possible, the core changes are as follows:

* I removed `check_replace`, as far as I can tell we only care about the case where the crs is changed and I think the new logic `st_crs<-.sfc` is cleaner and covers the necessary case.

* Allowing lists as a valid argument for `st_crs<-.sfc` seemed weird to me, I opted to just allow for crs class objects and then added a helper function to handle the list -> crs conversion needed by st_sfc (which is the only use case I found for a list)

* Switched epsgFromProj4 to epsg_from_proj4string for the sake of consistency (it seems likely this function will be used again internally at some point)

* ~st_read currently returns 0 for epsg for some objects, I'm fairly confident this is equivalent to no epsg - to avoid handling this additional special case with the crs code I opted to set the epsg attribute to NA_integer_ in st_read~

* Moved handling of epsg = 0 back to `st_crs<-.sfc` since some of the geometry functions can also produce this

There were a surprisingly large number of edge cases for these relatively small changes, hopefully I caught them all.