### PR TITLE
tidy geom.R/st_combine doc entry

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -183,7 +183,6 @@ st_segmentize  = function(x, dfMaxLength)
 
 #' @name geos
 #' @export
-#' @examples
 #' @details \code{st_combine} combines geometries without resolving borders. 
 #' st_combine(nc)
 st_combine = function(x) {


### PR DESCRIPTION
Edzer,
More a chance to ask you: Why are the roxygen entries not wrapped at 80 characters? CRAN does this anyway, but without it they effectively can't be read from the source (notably not easily at all on github), which is kinda annoying.