### PR TITLE
st_read_db and st_write_db now handle and preserve the srid correctly

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -37,13 +37,13 @@ st_read_db = function(conn = NULL, table, query = paste("select * from ", table,
 			SRID = dbGetQuery(conn, paste0("select srid from geometry_columns where f_table_name = '", table, "';"))[[1]]
 			ret = dbGetQuery(conn, paste("select proj4text from spatial_ref_sys where srid =", SRID, ";"))
 			if (nrow(ret))
-				SRID
+				structure(list(epsg=SRID, proj4string=ret[[1]]), class = "crs")
 			else
 				NA_crs_
 		}
 	if (missing(EWKB))
 		EWKB = inherits(conn, "PostgreSQLConnection") || inherits(conn, "PqConnection")
-    tbl[[geom_column]] = st_as_sfc(structure(tbl[[geom_column]], class = "WKB"), EWKB = EWKB, crs = SRID)
+    tbl[[geom_column]] = st_as_sfc(structure(tbl[[geom_column]], class = "WKB"), EWKB = EWKB, crs = crs)
 	st_as_sf(tbl, ...)
 }
 

--- a/R/db.R
+++ b/R/db.R
@@ -37,7 +37,7 @@ st_read_db = function(conn = NULL, table, query = paste("select * from ", table,
 			SRID = dbGetQuery(conn, paste0("select srid from geometry_columns where f_table_name = '", table, "';"))[[1]]
 			ret = dbGetQuery(conn, paste("select proj4text from spatial_ref_sys where srid =", SRID, ";"))
 			if (nrow(ret))
-				structure(list(epsg=SRID, proj4string=ret[[1]]), class = "crs")
+				make_crs(ret[[1]])
 			else
 				NA_crs_
 		}


### PR DESCRIPTION
Hi, 

`st_read_db` and `st_write_db` are currently losing the projection information when transferring from/to a database.

Most changes needed to fix this are minor. However, in order to make it work for the WKB transfer mode, I had to use EWKB instead of plain WKB (line 115). I am unsure whether this could introduce a portability problem to DBs other than PostGIS. What do you think?

An example:
With the current version of `sf` I get:
```r
data(meuse)
sf <- st_as_sf(meuse, coords = c("x", "y"), crs = 28992)
cr <- st_crs(sf)
cr
#>$epsg
#>[1] 28992
#>
#>$proj4string
#>[1] "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.4171,50.3319,465.5524,-0.398957388243134,0.343987817378283,-1.87740163998045,4.0725 +units=m +no_defs"
#>
#>attr(,"class")
#>[1] "crs"

## Export to DB; with projection
st_write_db(con, sf, "meuse_tbl_txt", binary = FALSE)
st_write_db(con, sf, "meuse_tbl_bin", binary = TRUE)

## Import from DB; projection is gone
st_crs(st_read_db(con, "meuse_tbl_txt"))
#>$epsg
#>[1] NA
#>
#>$proj4string
#>[1] NA
#>
#>attr(,"class")
#>[1] "crs"

st_crs(st_read_db(con, "meuse_tbl_bin"))
#>$epsg
#>[1] NA
#>
#>$proj4string
#>[1] NA
#>
#>attr(,"class")
#>[1] "crs"

```

With my proposed patch it works as it should:
```r
## Export to DB; with projection
st_write_db(con, sf, "meuse_tbl_txt", binary = FALSE)
st_write_db(con, sf, "meuse_tbl_bin", binary = TRUE)

## Import from DB; projection is gone
crt <- st_crs(st_read_db(con, "meuse_tbl_txt"))
crb <- st_crs(st_read_db(con, "meuse_tbl_bin"))
all.equal(cr, crt)
#>[1] TRUE
all.equal(cr, crb)
#>[1] TRUE
crt
#>$epsg
#>[1] 28992
#>
#>$proj4string
#>[1] "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.4171,50.3319,465.5524,-0.398957388243134,0.343987817378283,-1.87740163998045,4.0725 +units=m +no_defs"
#>
#>attr(,"class")
#>[1] "crs"
```



