### PR TITLE
Add examples showing how n works in st_line_sample

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -368,6 +368,8 @@ st_sym_difference = function(x, y) {
 #' ls = st_sfc(st_linestring(rbind(c(0,0),c(0,1))),
 #'   st_linestring(rbind(c(0,0),c(.1,0))), crs = 4326) 
 #' try(st_line_sample(ls, density = 1/1000)) # error
+#' st_line_sample(st_transform(ls, 3857), n = 5) # five points for each line
+#' st_line_sample(st_transform(ls, 3857), n = c(1, 3)) # one and three points
 #' st_line_sample(st_transform(ls, 3857), density = 1/1000) # one per km
 #' st_line_sample(st_transform(ls, 3857), density = c(1/1000, 1/10000)) # one per km, one per 10 km
 st_line_sample = function(x, n, density, type = "regular") {

--- a/man/geos.Rd
+++ b/man/geos.Rd
@@ -200,6 +200,8 @@ st_line_sample(ls, density = 1)
 ls = st_sfc(st_linestring(rbind(c(0,0),c(0,1))),
   st_linestring(rbind(c(0,0),c(.1,0))), crs = 4326) 
 try(st_line_sample(ls, density = 1/1000)) # error
+st_line_sample(st_transform(ls, 3857), n = 5) # five points for each line
+st_line_sample(st_transform(ls, 3857), n = c(1, 3)) # one and three points
 st_line_sample(st_transform(ls, 3857), density = 1/1000) # one per km
 st_line_sample(st_transform(ls, 3857), density = c(1/1000, 1/10000)) # one per km, one per 10 km
 }


### PR DESCRIPTION
I think if `length(n) == 1` the *total* sample size should be `n`, not `n * length(x)`.

To implement this is started writing:

```r
	  if(length(n) == 1)
	    n = n * l / sum(l)
```

But then was going to add another conditional in case rounding `n` caused problems but then realised it was getting a little complex! Any ideas? It will definitely useful to be able to set n and then distribute them according to line length. 

Happy to say it works now and this is sufficient to solve my problem + like that it gives the user low level access to the number of lines sampled per line.