### PR TITLE
preserve geometry on select

### DIFF
--- a/R/tidy.R
+++ b/R/tidy.R
@@ -74,12 +74,9 @@ transmute_.sf <- function(.data, ..., .dots) {
 #' nc %>% select(SID74, SID79, geometry) %>% names()
 #' nc %>% select(SID74, SID79) %>% class()
 #' nc %>% select(SID74, SID79, geometry) %>% class()
-select_.sf <- function(.data, ..., .dots) {
-	ret = NextMethod()
-	if (any(sapply(ret, function(x) inherits(x, "sfc"))))
-		st_as_sf(ret)
-	else
-		structure(ret, class = class(ret)[-1])
+select_.sf <- function(.data, ..., .dots=NULL) {
+  .dots <- c(.dots, attr(.data, "sf_column")) 
+  NextMethod()
 }
 
 #' @name dplyr

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -1,0 +1,9 @@
+context("sf: dplyr syntax")
+
+library(dplyr)
+nc <- st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
+
+test_that("select ", {
+  expect_true(nc %>% select_("AREA", attr(., "sf_column"))  %>% inherits("sf"))
+  expect_true(nc %>% select(AREA) %>% inherits("sf"))
+})


### PR DESCRIPTION
`.dots = NULL` is a little trick to save from checking for `missing(.dots)`. I don't know how dangerous it is, but it seems to work fine.

closes #121