### PR TITLE
keep rownames as rownames when reading from db

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -24,6 +24,10 @@ st_read_db = function(conn = NULL, table, query = paste("select * from ", table,
 		stop("no connection provided")
   	# suppress warning about unknown type "geometry":
 	suppressWarnings(tbl <- dbGetQuery(conn, query))
+    if("row.names" %in% colnames(tbl)){
+        row.names(tbl) = tbl[["row.names"]]
+        tbl = tbl[,setdiff(colnames(tbl), "row.names")]
+    }
 	if (is.null(geom_column)) { # try find the geometry column:
 		gc = try(dbReadTable(conn, "geometry_columns"))
 		geom_column = if (class(gc) == "try-error" || missing(table))


### PR DESCRIPTION
Hi, 

`st_read_db` does not assign rownames when reading from a database but instead returns them as additional column "row.names" because it is queried using `dbGetQuery`.
Using `dbReadTable` as an alternative would keep rownames but lose the option to specify a `SELECT` query.
Therefore I'd simply suggest to re-assign rownames if a column called "row.names" exists.

A test example:
```r
library(sp)
library(sf)
example(meuse, ask = FALSE, echo = FALSE)
sf <- st_as_sf(meuse)
rownames(sf) <- paste0("rn", 1:nrow(sf))
st_write_db(con , sf, "test")
st_read_db(con, "test")
```
