### PR TITLE
Fail to plot characters

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -427,6 +427,9 @@ sf.colors = function (n = 10, xc, cutoff.tails = c(0.35, 0.2), alpha = 1, catego
     		rgb(r, g, b, alpha)
 		}
 	} else {
+	  if (is.character(xc)) {
+	    xc <- as.factor(xc)
+	  }
 		if (is.factor(xc))
 			sf.colors(nlevels(xc), categorical = TRUE)[as.numeric(xc)]
 		else {

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -1,0 +1,7 @@
+context("sp: plot")
+
+test_that("plot.sf() support characters", {
+  m <- list(rbind(c(0,0), c(1,0), c(1, 1), c(0,1), c(0,0))) %>% st_polygon()
+  x <- data.frame(a = c("a", "b"), stringsAsFactors = FALSE) %>% st_as_sf(geom = st_sfc(m, m + 2))
+  expect_silent(plot(x))
+})


### PR DESCRIPTION
If characters where not converted to factors, `sf.colors()` failed to cut.