### PR TITLE
Allow backslashes in guess_driver

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -186,7 +186,7 @@ guess_driver = function(dsn) {
   
 	# find match: try extension first
 	drv = extension_map[tolower(tools::file_ext(dsn))]
-	if (any(grep(":", gsub(":/", "/", dsn)))) {
+	if (any(grep(":", gsub(":[/\\]", "/", dsn)))) {
 			drv = prefix_map[tolower(strsplit(dsn, ":")[[1]][1])]
 	}
 	drv <- unlist(drv)

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -134,3 +134,8 @@ test_that("driver operations", {
   expect_equal(guess_driver_can_write("x.csv"), c("csv" = "CSV"))
   expect_equal(guess_driver_can_write("x.gml"), c("gml" = "GML"))
 })
+
+test_that("guess driver on windows with backslashes (#127)", {
+    expect_identical(guess_driver("c:\\Temp\\this.shp"), 
+                     guess_driver("c:/Temp/this.shp"))
+})

--- a/tests/testthat/test_tm.R
+++ b/tests/testthat/test_tm.R
@@ -1,21 +1,19 @@
-context("st_read")
+context("sf: date and time")
 
 test_that("st_read and write handle date and time", {
-  library(sf)
-  Sys.setenv(TZ="UTC")
-  x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3, 
-	  geometry = st_sfc(st_point(c(1,1)),st_point(c(2,2))))
-  shp <- paste0("test_shapefile", c(".shp", ".shx", ".dbf"))
-  gpkg <- paste0(tempfile(), ".gpkg")
-  on.exit(file.remove(shp))
-  st_write(x[-4], shp[1], quiet = TRUE)
-  x2 = st_read(shp[1], quiet = TRUE)
-  expect_equal(x[-4], x2)
-  if (Sys.getenv("USER") %in% c("edzer", "travis")) { # 
-     x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3, 
-	    geom = st_sfc(st_point(c(1,1)),st_point(c(2,2))))
-     st_write(x, gpkg, quiet = TRUE)
-	 x2 = st_read(gpkg, quiet = TRUE)
-     expect_equal(x, x2)
-  }
+    x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3, 
+              geometry = st_sfc(st_point(c(1,1)), st_point(c(2,2))))
+    shp <- paste0(tempfile(), ".shp")
+    gpkg <- paste0(tempfile(), ".gpkg")
+    
+    st_write(x[-4], shp[1], quiet = TRUE)
+    x2 = st_read(shp[1], quiet = TRUE)
+    expect_equal(x[-4], x2)
+    
+    st_write(x, gpkg, quiet = TRUE)
+    x2 = st_read(gpkg, quiet = TRUE)
+    expect_equal(x[["a"]], x2[["a"]])
+    expect_equal(x[["b"]], x2[["b"]])
+    expect_equal(x[["dt"]], x2[["dt"]])
+    expect_equal(x[["tm"]], x2[["tm"]])
 })


### PR DESCRIPTION
Fix #127. Tested on Windows.