### PR TITLE
Suppress codecov comments

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ blog
 README.md
 CONDUCT.md
 rdev
+^codecov\.yml$

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
This suppresses the comment message that codecov adds to all pull requests - you can still access the information in the build report pane.