### PR TITLE
Preserve crs objects

### DIFF
--- a/R/crs.R
+++ b/R/crs.R
@@ -69,6 +69,10 @@ st_crs.sfc = function(x, ...) attr(x, "crs")
 #' @export
 st_crs.bbox = function(x, ...) attr(x, "crs")
 
+#' @name st_crs
+#' @export
+st_crs.crs = function(x, ...) x
+
 #' @export
 st_crs.default = function(x, ...) NA_crs_
 


### PR DESCRIPTION
e.g. so you can use `st_is_latlon()` directly on a crs object.