### PR TITLE
speed up bulk point creation from data frame

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -39,8 +39,15 @@ st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 		else
 			x$geometry = st_as_sfc(as.character(x[[wkt]]))
 	} else if (! missing(coords)) {
-		x$geometry = do.call(st_sfc, c(lapply(seq_len(nrow(x)), 
-				function(i) st_point(unlist(x[i, coords]), dim = dim))))
+	  classdim = sf:::getClassDim(rep(0, length(coords)), length(coords), dim, "POINT")
+	  x$geometry =  structure( lapply(split(as.vector(t(as.matrix(x[, coords]))), 
+	               rep(seq_len(nrow(x)), each = length(coords))), 
+	         function(vec) structure(vec, class = classdim)), 
+	         n_empty = 0L, precision = 0, crs = st_crs(NA), 
+	         bbox = c(xmin = min(x[[coords[1]]], na.rm = TRUE), ymin = min(x[[coords[2]]], na.rm = TRUE), 
+	                  xmax = max(x[[coords[1]]], na.rm = TRUE),  ymax = max(x[[coords[2]]], na.rm = TRUE)), 
+	         class =  c("sfc_POINT", "sfc" ))
+	            
 		if (remove)
 			x[coords] = NULL
 	}

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -53,3 +53,17 @@ test_that("rbind/cbind work", {
   expect_warning(cbind(x, x, x))
   rbind(x, x, x)
 })
+
+test_that("st_as_sf bulk points work", {
+  data(meuse, package = "sp") # load data.frame from sp
+  x <- meuse
+  meuse_sf = st_as_sf(x, coords = c("x", "y"), crs = 28992)
+  xyz_sf = st_as_sf(x, coords = c("y", "x", "dist"))
+  xym_sf = st_as_sf(x, coords = c("y", "x", "dist"), dim = "XYM")
+  xyzm_sf = st_as_sf(x, coords = c("x", "y", "dist", "zinc"), dim = "XYM")
+  expect_identical(class(meuse_sf), c("sf", "data.frame"))
+  expect_identical(class(xyz_sf), c("sf", "data.frame"))
+  expect_identical(class(xym_sf), c("sf", "data.frame"))
+  expect_identical(class(xyzm_sf), c("sf", "data.frame"))
+  
+})


### PR DESCRIPTION
The bulk point creation in st_as_sf.data.frame is a bit slow. 

I've short-circuited the creation of the POINT geometries, and also created the sfc structure directly which makes this quite a bit faster. 

For the benchmark below with 1e4 points I see 2 seconds (vs 9 seconds) by vectorizing the `st_point` build and then to < 1 second by further avoiding checks in `st_sfc`

```R
n <- 1e4
set.seed(1)
d <- data.frame(x = rnorm(n), y = rnorm(n), z = rnorm(n), m = rnorm(n), a = seq_len(n))

library(sf)
system.time({
  aa <- st_as_sf(d, coords = c("x", "y"), crs = "+init=epsg:4326")
  bb <- st_as_sf(d, coords = c("x", "y", "z"))
  cc <- st_as_sf(d, coords = c("x", "y", "m"), dim = "XYM")
  dd <- st_as_sf(d, coords = c("x", "y", "z", "m"), dim = "XYZM")
  
})

class(st_geometry(aa)[[1]])
class(st_geometry(bb)[[1]])
class(st_geometry(cc)[[1]])
class(st_geometry(dd)[[1]])

```