### PR TITLE
add geometrycollection grob

### DIFF
--- a/R/grid.R
+++ b/R/grid.R
@@ -46,6 +46,11 @@ st_as_grob.MULTIPOLYGON = function(x, ..., default.units = "native") {
 	get_l = function(x) unlist(sapply(x, function(y) sapply(y, nrow)))
 	pathGrob(get_x(x), get_y(x), id.lengths = get_l(x), ..., default.units = default.units)
 }
+#' @export
+st_as_grob.GEOMETRYCOLLECTION <- function(x, ..., default.units = "native") {
+  do.call(grid::grobTree, lapply(x, st_as_grob, ...))
+}
+
 
 #' Create viewport from sf, sfc or sfg object
 #' 


### PR DESCRIPTION
Add grobTree handling for GEOMETRYCOLLECTION.  This PR adds a `st_as_grob.GEOMETRYCOLLECTION` method to collect the component grobs in the gc. 

(I'm using latest sf 059479d   and ggplot2 73e77b6c)

Examples: 

```R
library(sf)
library(ggplot2)
example(st_read)
d1 <- nc[4:7, ]
d1$target <- c("MULTILINESTRING", "MULTIPOINT", "POLYGON", "MULTILINESTRING")

a <- st_sf(geometry = st_sfc(st_geometrycollection(lapply(seq_len(nrow(d1)), 
                                                          function(x) st_cast(st_geometry(d1)[[x]], d1$target[x]))), 
                             st_geometry(nc)[[8]],           st_geometry(nc)[[9]], crs = st_crs(nc)), 
           id = 1:3)
ggplot(a, aes(col = id, fill = id, size = id)) + geom_sf()
             
```

![image](https://cloud.githubusercontent.com/assets/4107631/22962247/dcf750a0-f39f-11e6-85c7-65a57a67d99b.png)


Slightly more realistic use-case with `sfdct`: 

```R
devtools::install_github("mdsumner/sfdct")
library(sfdct)
ct <- ct_triangulate(nc[4:9, ], q = 25, D = TRUE)

ggplot(ct, aes(col = NAME)) + geom_sf()
```

![image](https://cloud.githubusercontent.com/assets/4107631/22962236/c114de52-f39f-11e6-9be5-283ae49e6491.png)
