### PR TITLE
Document about st_ prefix

### DIFF
--- a/vignettes/sf1.Rmd
+++ b/vignettes/sf1.Rmd
@@ -132,7 +132,8 @@ system, e.g. a [measurement unit](https://CRAN.R-project.org/package=units).
 
 Package `sf` represents simple features as native R objects.
 All functions and methods in `sf` are prefixed by `st_`, so that
-they are easily found by command-line completion.  Simple features
+they are easily found by command-line completion ("st" stands for
+"spatial type", which is originated from PostGIS). Simple features
 are implemented as R native data, using simple data structures (S3
 classes, lists, matrix, vector).  Typical use involves reading,
 manipulating and writing of sets of features, with attributes


### PR DESCRIPTION
Hi,

I saw several people (including me 😃 ) got confused why the prefix is `st_`, not `sf_`. I guess this is just because I'm a newbie to GIS and it will be OK for most of GIS guys, who are familiar with the `ST_` prefix of PostGIS, right? So, I don't complain about the prefix, but could you consider add some sentence about what `st` stands for.

(This PR is an example and please close this anytime. I'm not confident with my English...)