### PR TITLE
change src/geos.cpp int *.size() -> unsigned *.size()

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -273,7 +273,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 				std::vector<size_t> tree_sel, sel;
 				if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 					GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-				for (unsigned j = 1; j < tree_sel.size(); j++)
+				for (size_t j = 0; j < tree_sel.size(); j++)
 					if (chk_(GEOSRelatePattern_r(hGEOSCtxt, gmv0[i], gmv1[tree_sel[j]], pattern.c_str())))
 						sel.push_back(tree_sel[j] + 1); // 1-based
 				if (sparse) {
@@ -294,7 +294,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 					std::vector<size_t> tree_sel, sel;
 					if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 						GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-					for (unsigned j = 1; j < tree_sel.size(); j++)
+					for (size_t j = 0; j < tree_sel.size(); j++)
 						if (chk_(logical_fn(hGEOSCtxt, pr, gmv1[tree_sel[j]])))
 							sel.push_back(tree_sel[j] + 1); // 1-based
 					if (sparse) {
@@ -312,7 +312,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 					std::vector<size_t> tree_sel, sel;
 					if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 						GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-					for (unsigned j = 0; j < tree_sel.size(); j++)
+					for (size_t j = 0; j < tree_sel.size(); j++)
 						if (chk_(logical_fn(hGEOSCtxt, gmv0[i], gmv1[tree_sel[j]])))
 							sel.push_back(tree_sel[j] + 1); // 1-based
 					if (sparse) {

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -273,7 +273,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 				std::vector<size_t> tree_sel, sel;
 				if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 					GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-				for (int j = 0; j < tree_sel.size(); j++)
+				for (unsigned j = 1; j < tree_sel.size(); j++)
 					if (chk_(GEOSRelatePattern_r(hGEOSCtxt, gmv0[i], gmv1[tree_sel[j]], pattern.c_str())))
 						sel.push_back(tree_sel[j] + 1); // 1-based
 				if (sparse) {
@@ -294,7 +294,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 					std::vector<size_t> tree_sel, sel;
 					if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 						GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-					for (int j = 0; j < tree_sel.size(); j++)
+					for (unsigned j = 1; j < tree_sel.size(); j++)
 						if (chk_(logical_fn(hGEOSCtxt, pr, gmv1[tree_sel[j]])))
 							sel.push_back(tree_sel[j] + 1); // 1-based
 					if (sparse) {
@@ -312,7 +312,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 					std::vector<size_t> tree_sel, sel;
 					if (! GEOSisEmpty_r(hGEOSCtxt, gmv0[i]))
 						GEOSSTRtree_query_r(hGEOSCtxt, tree1, gmv0[i], cb, &tree_sel);
-					for (int j = 0; j < tree_sel.size(); j++)
+					for (unsigned j = 0; j < tree_sel.size(); j++)
 						if (chk_(logical_fn(hGEOSCtxt, gmv0[i], gmv1[tree_sel[j]])))
 							sel.push_back(tree_sel[j] + 1); // 1-based
 					if (sparse) {


### PR DESCRIPTION
clang output on `-Wall -pedantic` compile of latest version (0.5-1):
```
geos.cpp: In function ‘Rcpp::List CPL_geos_binop(Rcpp::List, Rcpp::List, std::__cxx11::string, double, std::__cxx11::string, bool, bool)’:
geos.cpp:276:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int j = 0; j < tree_sel.size(); j++)
                       ^
geos.cpp:297:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
      for (int j = 0; j < tree_sel.size(); j++)
                        ^
geos.cpp:315:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
      for (int j = 0; j < tree_sel.size(); j++)
                        ^
```
This fixes that. Note also that travis checks for dependency packages require that they pass `clang/clang++ -Wall -pedantic` (plus other flags), and so travis would refuse to install this as a dep for another package, even though travis builds of the repo itself will pass. (I learnt this the hard way: [see this example](https://travis-ci.org/ropensci/osmplotr/jobs/244886520#L3759-L3790)).