### PR TITLE
Makes DBI dependency specification stricter (correct)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     grid, 
     methods, 
     Rcpp, 
-    DBI,
+    DBI (>= 0.5),
     units (>= 0.4),
 	magrittr
 Suggests: 


### PR DESCRIPTION
The `DBI::dbExecute()` method [appeared in v0.5 of `DBI`](https://cran.rstudio.com/web/packages/DBI/news.html), so `sf` fails to install if using previous `DBI` versions.